### PR TITLE
DarkGravity3 fix and starting difficulties added

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -49,6 +49,17 @@ public:
         nDefaultPort = 9265;
         nRPCPort = 9266;
         bnProofOfWorkLimit = CBigNum(~uint256(0) >> 32);
+
+        bnProofOfWorkLimitMA[ALGO_SCRYPT]      = CBigNum(~uint256(0) >> 40); // 10 scrypt miners: 1 GH/s
+        bnProofOfWorkLimitMA[ALGO_SHA256D]     = CBigNum(~uint256(0) >> 50); // 1 sha256d miner: 14 Th/s
+        bnProofOfWorkLimitMA[ALGO_YESCRYPT]    = CBigNum(~uint256(0) >> 19); // 1 CPU: 0.5 Kh/s
+        bnProofOfWorkLimitMA[ALGO_ARGON2]      = CBigNum(~uint256(0) >> 18); // 1 CPU: 0,2 Kh/s
+        bnProofOfWorkLimitMA[ALGO_X17]         = CBigNum(~uint256(0) >> 34); // 1 GPU miner: 10 Mh/s
+        bnProofOfWorkLimitMA[ALGO_LYRA2REv2]   = CBigNum(~uint256(0) >> 35); // 1 GPU miner: 35 Mh/s
+        bnProofOfWorkLimitMA[ALGO_EQUIHASH]    = CBigNum(~uint256(0) >> 19); // 1 GPU 400 Sol/s
+        bnProofOfWorkLimitMA[ALGO_CRYPTONIGHT] = CBigNum(~uint256(0) >> 20); // 1 gpu 1 KH/s
+
+
         nSubsidyHalvingInterval = 788000;
 	fStrictChainId = true;
 	nAuxpowChainId = 0x005B;

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -51,7 +51,7 @@ public:
         bnProofOfWorkLimit = CBigNum(~uint256(0) >> 32);
 
         bnProofOfWorkLimitMA[ALGO_SCRYPT]      = CBigNum(~uint256(0) >> 40); // 10 scrypt miners: 1 GH/s
-        bnProofOfWorkLimitMA[ALGO_SHA256D]     = CBigNum(~uint256(0) >> 50); // 1 sha256d miner: 14 Th/s
+        bnProofOfWorkLimitMA[ALGO_SHA256D]     = CBigNum(~uint256(0) >> 54); // 1 sha256d miner: 14 Th/s
         bnProofOfWorkLimitMA[ALGO_YESCRYPT]    = CBigNum(~uint256(0) >> 19); // 1 CPU: 0.5 Kh/s
         bnProofOfWorkLimitMA[ALGO_ARGON2]      = CBigNum(~uint256(0) >> 18); // 1 CPU: 0,2 Kh/s
         bnProofOfWorkLimitMA[ALGO_X17]         = CBigNum(~uint256(0) >> 34); // 1 GPU miner: 10 Mh/s

--- a/src/chainparams.h
+++ b/src/chainparams.h
@@ -9,6 +9,7 @@
 
 #include "bignum.h"
 #include "uint256.h"
+#include "pureheader.h"
 
 #include <vector>
 
@@ -57,7 +58,10 @@ public:
     const MessageStartChars& MessageStart() const { return pchMessageStart; }
     const vector<unsigned char>& AlertKey() const { return vAlertPubKey; }
     int GetDefaultPort() const { return nDefaultPort; }
+
     const CBigNum& ProofOfWorkLimit() const { return bnProofOfWorkLimit; }
+    const CBigNum& ProofOfWorkLimitMA(ALGO algo) const { return bnProofOfWorkLimitMA[algo]; }
+
     int SubsidyHalvingInterval() const { return nSubsidyHalvingInterval; }
     int SubsidyInterimInterval() const { return nSubsidyHalvingInterval/2; }
     virtual const CBlock& GenesisBlock() const = 0;
@@ -84,6 +88,7 @@ protected:
     int nDefaultPort;
     int nRPCPort;
     CBigNum bnProofOfWorkLimit;
+    CBigNum bnProofOfWorkLimitMA[NUM_ALGOS];
     int nSubsidyHalvingInterval;
     string strDataDir;
     vector<CDNSSeedData> vSeeds;

--- a/src/pureheader.h
+++ b/src/pureheader.h
@@ -10,7 +10,7 @@
 
 const int NUM_ALGOS = 8;
 
-enum {
+enum ALGO {
   ALGO_SCRYPT = 0,
   ALGO_SHA256D = 1,
   ALGO_YESCRYPT = 2,


### PR DESCRIPTION
Fix for:
1. For the first block of every new algo. Difficulty was 0.
2. For the first 25 block difficulty adjustment wasn't calculated, so difficulty adjustment was slow.

Also:
1. DarkGravityWave3 sliding window reduced to 11 blocks (3h), from 25 blocks(6.6h), to increase speed of adjustment and to fight hash attack.
2. Added starting difficulties for each algo.